### PR TITLE
Add load callback parameter

### DIFF
--- a/bootstrap-font-picker.js
+++ b/bootstrap-font-picker.js
@@ -55,7 +55,7 @@
         _bind();
 
         if (typeof options.load === "function") {
-          options.load();
+          options.load.call($element);
         }
       }, function() {
         console.log("Failed to retrieve template.html");


### PR DESCRIPTION
Pass a callback function as the value of the "load" parameter when initializing the font picker. That callback will be called when the plugin has successfully loaded.
