### PR TITLE
Rename repo to bootstrap-form-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-bootstrap-font-picker
+Bootstrap Form Components
 =====================
-[![Build Status](http://107.170.20.223:8080/job/Component-Bootstrap-Font-Picker-Master/badge/icon)](http://107.170.20.223:8080/job/Component-Bootstrap-Font-Picker-Master/)
+[![Build Status](http://107.170.20.223:8080/job/Component-Bootstrap-Form-Components-Master/badge/icon)](http://107.170.20.223:8080/job/Component-Bootstrap-Form-Components-Master/)
 
-Bootstrap Font Picker jQuery Plugin
+## What components are included?
+- A simple jQuery-based Font picker
+- A simple jQuery-based font size picker
+
+## How do I use the components?
+In your [bower](http://bower.io/)-enabled project, run
+
+```bash
+bower install --save git://github.com/Rise-Vision/bootstrap-form-components.git
+```

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "bootstrap-font-picker",
-  "version": "0.1.7",
-  "homepage": "http://github.com/Rise-Vision/bootstrap-font-picker",
+  "name": "bootstrap-form-components",
+  "version": "0.1.8",
+  "homepage": "http://github.com/Rise-Vision/bootstrap-form-components",
   "authors": [
     "Rise Vision"
   ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,8 +102,8 @@
       });
   });
 
-  gulp.task('concat', ['config'], function () {
-    return gulp.src(['./src/config/config.js', './templates/**/*.js', './src/lib/*.js', './src/*.js'])
+  gulp.task('concat-fontpicker', ['config'], function () {
+    return gulp.src(['./src/config/config.js', './templates/template.html.js', './src/lib/font-loader.js', './src/font-picker.js'])
     .pipe(concat('bootstrap-font-picker.js'))
     .pipe(gulp.dest('./dist/js'));
   });
@@ -114,7 +114,7 @@
     .pipe(gulp.dest('./dist/js/angular'));
   });
 
-  gulp.task('build', ['css-min', 'html2js', 'concat', 'concat-angular']);
+  gulp.task('build', ['css-min', 'html2js', 'concat-fontpicker', 'concat-angular']);
 
   gulp.task('test', ['e2e:test']);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bootstrap-font-picker",
-  "version": "0.1.7",
+  "name": "bootstrap-form-components",
+  "version": "0.1.8",
   "description": "Bootstrap Font Picker jQuery Plugin",
   "directories": {
     "test": "test"
@@ -10,14 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Rise-Vision/bootstrap-font-picker.git"
+    "url": "https://github.com/Rise-Vision/bootstrap-form-components.git"
   },
   "author": "Rise Vision",
   "license": "GPLv3",
   "bugs": {
-    "url": "https://github.com/Rise-Vision/bootstrap-font-picker/issues"
+    "url": "https://github.com/Rise-Vision/bootstrap-form-components/issues"
   },
-  "homepage": "https://github.com/Rise-Vision/bootstrap-font-picker",
+  "homepage": "https://github.com/Rise-Vision/bootstrap-form-components",
   "devDependencies": {
     "casperjs": "^1.1.0-beta3",
     "chai": "~1.9.1",


### PR DESCRIPTION
- Update gulp contact tasks for font picker to have more targeted source
  files
- Rename package name to bootstrap-form-components in bower.json and
  package.json
- Update Jenkins build routes in README file
- Basic instruction in README on how to use the bower component
- Version bump to 0.1.8

Fix #12
