### PR TITLE
Chore/upgrade font and font size pickers

### DIFF
--- a/dist/css/all.css
+++ b/dist/css/all.css
@@ -40,33 +40,34 @@
 .wysiwyg-font-size-96 {
   font-size: 96px; }
 
-.font-picker-font .modal {
-  top: 100px;
-  z-index: 3; }
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased; }
 
-.font-picker-size .bfh-selectbox a.bfh-selectbox-toggle, .font-picker-size .bfh-selectbox .bfh-selectbox-options, .font-picker-size .bfh-selectbox .bfh-selectbox-options ul {
-  min-width: 80px;
-  max-width: 80px;
-  width: 80px; }
-.font-picker-size .bfh-selectbox-options ul li {
-  min-width: 78px;
-  max-width: 78px;
-  width: 78px; }
-.font-picker-size .bfh-selectbox-filter {
-  width: 60px; }
-.font-picker-size a.bfh-selectbox-option, .font-picker-size .bfh-selectbox-large {
-  width: 50px; }
+h2 {
+  font-size: 24px;
+  font-weight: bold; }
 
-input.form-control.color-picker {
-  height: 38px; }
+.modal-header, .modal-footer {
+  border: none; }
 
-.font-picker-custom-font {
-  display: none; }
+.close {
+  opacity: 1; }
+  .close .glyphicon::before {
+    color: #777; }
 
-.font-picker-text {
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  background-color: #efefef;
-  text-align: center;
-  padding: 15px; }
+.glyphicon {
+  font-size: 18px;
+  vertical-align: top; }
+
+.btn-primary {
+  background-color: #2d60ad;
+  border-color: #2d60ad;
+  border-radius: 0; }
+  .btn-primary:hover {
+    background-color: #2d60ad;
+    border-color: #2d60ad; }
+
+.icon-right {
+  margin-left: 10px; }

--- a/dist/css/all.min.css
+++ b/dist/css/all.min.css
@@ -12,11 +12,12 @@
 .wysiwyg-font-size-60{font-size:60px}
 .wysiwyg-font-size-72{font-size:72px}
 .wysiwyg-font-size-96{font-size:96px}
-.font-picker-font .modal{top:100px;z-index:3}
-.font-picker-size .bfh-selectbox .bfh-selectbox-options,.font-picker-size .bfh-selectbox .bfh-selectbox-options ul,.font-picker-size .bfh-selectbox a.bfh-selectbox-toggle{min-width:80px;max-width:80px;width:80px}
-.font-picker-size .bfh-selectbox-options ul li{min-width:78px;max-width:78px;width:78px}
-.font-picker-size .bfh-selectbox-filter{width:60px}
-.font-picker-size .bfh-selectbox-large,.font-picker-size a.bfh-selectbox-option{width:50px}
-input.form-control.color-picker{height:38px}
-.font-picker-custom-font{display:none}
-.font-picker-text{-webkit-border-radius:8px;-moz-border-radius:8px;border-radius:8px;background-color:#efefef;text-align:center;padding:15px}
+body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased;font-smoothing:antialiased}
+h2{font-size:24px;font-weight:700}
+.modal-footer,.modal-header{border:none}
+.close{opacity:1}
+.close .glyphicon::before{color:#777}
+.glyphicon{font-size:18px;vertical-align:top}
+.btn-primary{background-color:#2d60ad;border-color:#2d60ad;border-radius:0}
+.btn-primary:hover{background-color:#2d60ad;border-color:#2d60ad}
+.icon-right{margin-left:10px}

--- a/dist/js/bootstrap-font-picker.js
+++ b/dist/js/bootstrap-font-picker.js
@@ -6,10 +6,10 @@ TEMPLATES['font-picker-template.html'] = "<!-- Font Family -->\n" +
     "     styled individually. -->\n" +
     "<div class=\"bfh-selectbox\">\n" +
     "  <input class=\"font-family\" type=\"hidden\" value=\"\">\n" +
-    "  <a class=\"bfh-selectbox-toggle\" role=\"button\" data-toggle=\"bfh-selectbox\"\n" +
+    "  <a class=\"bfh-selectbox-toggle form-control\" role=\"button\" data-toggle=\"bfh-selectbox\"\n" +
     "    href=\"#\">\n" +
-    "    <span class=\"bfh-selectbox-option bfh-selectbox-large\" data-option=\"\"></span>\n" +
-    "    <b class=\"caret\"></b>\n" +
+    "    <span class=\"bfh-selectbox-option\"></span>\n" +
+    "    <span class=\"caret selectbox-caret\"></span>\n" +
     "  </a>\n" +
     "  <div class=\"bfh-selectbox-options\">\n" +
     "    <div role=\"listbox\">\n" +
@@ -26,7 +26,7 @@ TEMPLATES['font-picker-template.html'] = "<!-- Font Family -->\n" +
     "      <div class=\"modal-header\">\n" +
     "        <button class=\"close\" type=\"button\" aria-hidden=\"true\"\n" +
     "          data-dismiss=\"modal\">\n" +
-    "          <i class=\"glyphicons remove_2\"></i>\n" +
+    "          <i class=\"glyphicon glyphicon-remove\"></i>\n" +
     "        </button>\n" +
     "        <h2 class=\"modal-title\">Google Fonts</h2>\n" +
     "      </div>\n" +
@@ -35,8 +35,8 @@ TEMPLATES['font-picker-template.html'] = "<!-- Font Family -->\n" +
     "      </div>\n" +
     "      <div class=\"modal-footer\">\n" +
     "        <button type=\"button\" class=\"btn btn-primary\" data-dismiss=\"modal\">\n" +
-    "          <span data-i18n=\"cancel\"></span>\n" +
-    "          <i class=\"glyphicons white remove_2 icon-right\"></i>\n" +
+    "          <span data-i18n=\"cancel\">Cancel</span>\n" +
+    "          <i class=\"glyphicon glyphicon-remove icon-right\"></i>\n" +
     "        </button>\n" +
     "      </div>\n" +
     "    </div>\n" +
@@ -51,7 +51,7 @@ TEMPLATES['font-picker-template.html'] = "<!-- Font Family -->\n" +
     "      <div class=\"modal-header no-border\">\n" +
     "        <button class=\"close\" type=\"button\" aria-hidden=\"true\"\n" +
     "          data-dismiss=\"modal\">\n" +
-    "          <i class=\"glyphicons remove_2\"></i>\n" +
+    "          <i class=\"glyphicon glyphicon-remove\"></i>\n" +
     "        </button>\n" +
     "        <h2 class=\"modal-title\">Custom Font</h2>\n" +
     "      </div>\n" +
@@ -63,12 +63,12 @@ TEMPLATES['font-picker-template.html'] = "<!-- Font Family -->\n" +
     "      </div>\n" +
     "      <div class=\"modal-footer no-border\">\n" +
     "        <button type=\"button\" class=\"save-custom-font btn btn-primary\">\n" +
-    "          <span data-i18n=\"save\"></span>\n" +
-    "          <i class=\"glyphicons white ok_2 icon-right\"></i>\n" +
+    "          <span data-i18n=\"save\">Save</span>\n" +
+    "          <i class=\"glyphicon glyphicon-ok icon-right\"></i>\n" +
     "        </button>\n" +
     "        <button type=\"button\" class=\"btn btn-primary\" data-dismiss=\"modal\">\n" +
-    "          <span data-i18n=\"cancel\"></span>\n" +
-    "          <i class=\"glyphicons white remove_2 icon-right\"></i>\n" +
+    "          <span data-i18n=\"cancel\">Cancel</span>\n" +
+    "          <i class=\"glyphicon glyphicon-remove icon-right\"></i>\n" +
     "        </button>\n" +
     "      </div>\n" +
     "    </div>\n" +

--- a/dist/js/bootstrap-font-size-picker.js
+++ b/dist/js/bootstrap-font-size-picker.js
@@ -19,17 +19,14 @@ var CONFIG = {};
      */
     function _init() {
       // Add the markup.
-      $element.append(
-          "<div class='bfh-selectbox'>" +
-          "<select class='form-control bfh-fontsizes'></select>" +
-          "</div>");
+      $element.append("<select class='form-control bfh-fontsizes'></select>");
 
       // Initialize the font size picker component.
       $element.find(".bfh-fontsizes").bfhfontsizes({
         "fontsize": options["font-size"]
       }).selectpicker();
 
-      $element.find(".bfh-selectbox").on("change.bfhselectbox", function(e) {
+      $element.find(".bfh-fontsizes").on("change.bfhselectbox", function(e) {
         $element.trigger("sizeChanged", getSize());
       });
     }

--- a/src/html/font-picker-template.html
+++ b/src/html/font-picker-template.html
@@ -3,10 +3,10 @@
      styled individually. -->
 <div class="bfh-selectbox">
   <input class="font-family" type="hidden" value="">
-  <a class="bfh-selectbox-toggle" role="button" data-toggle="bfh-selectbox"
+  <a class="bfh-selectbox-toggle form-control" role="button" data-toggle="bfh-selectbox"
     href="#">
-    <span class="bfh-selectbox-option bfh-selectbox-large" data-option=""></span>
-    <b class="caret"></b>
+    <span class="bfh-selectbox-option"></span>
+    <span class="caret selectbox-caret"></span>
   </a>
   <div class="bfh-selectbox-options">
     <div role="listbox">
@@ -23,7 +23,7 @@
       <div class="modal-header">
         <button class="close" type="button" aria-hidden="true"
           data-dismiss="modal">
-          <i class="glyphicons remove_2"></i>
+          <i class="glyphicon glyphicon-remove"></i>
         </button>
         <h2 class="modal-title">Google Fonts</h2>
       </div>
@@ -32,8 +32,8 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" data-dismiss="modal">
-          <span data-i18n="cancel"></span>
-          <i class="glyphicons white remove_2 icon-right"></i>
+          <span data-i18n="cancel">Cancel</span>
+          <i class="glyphicon glyphicon-remove icon-right"></i>
         </button>
       </div>
     </div>
@@ -48,7 +48,7 @@
       <div class="modal-header no-border">
         <button class="close" type="button" aria-hidden="true"
           data-dismiss="modal">
-          <i class="glyphicons remove_2"></i>
+          <i class="glyphicon glyphicon-remove"></i>
         </button>
         <h2 class="modal-title">Custom Font</h2>
       </div>
@@ -60,12 +60,12 @@
       </div>
       <div class="modal-footer no-border">
         <button type="button" class="save-custom-font btn btn-primary">
-          <span data-i18n="save"></span>
-          <i class="glyphicons white ok_2 icon-right"></i>
+          <span data-i18n="save">Save</span>
+          <i class="glyphicon glyphicon-ok icon-right"></i>
         </button>
         <button type="button" class="btn btn-primary" data-dismiss="modal">
-          <span data-i18n="cancel"></span>
-          <i class="glyphicons white remove_2 icon-right"></i>
+          <span data-i18n="cancel">Cancel</span>
+          <i class="glyphicon glyphicon-remove icon-right"></i>
         </button>
       </div>
     </div>

--- a/src/js/font-size-picker/font-size-picker.js
+++ b/src/js/font-size-picker/font-size-picker.js
@@ -17,17 +17,14 @@
      */
     function _init() {
       // Add the markup.
-      $element.append(
-          "<div class='bfh-selectbox'>" +
-          "<select class='form-control bfh-fontsizes'></select>" +
-          "</div>");
+      $element.append("<select class='form-control bfh-fontsizes'></select>");
 
       // Initialize the font size picker component.
       $element.find(".bfh-fontsizes").bfhfontsizes({
         "fontsize": options["font-size"]
       }).selectpicker();
 
-      $element.find(".bfh-selectbox").on("change.bfhselectbox", function(e) {
+      $element.find(".bfh-fontsizes").on("change.bfhselectbox", function(e) {
         $element.trigger("sizeChanged", getSize());
       });
     }

--- a/src/scss/bootstrap-fontpicker.scss
+++ b/src/scss/bootstrap-fontpicker.scss
@@ -1,45 +1,43 @@
-.font-picker-font .modal {
-    top: 100px;
-    z-index: 3;
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased;
 }
-.font-picker-size {
-  .bfh-selectbox {
-    a.bfh-selectbox-toggle,
-    .bfh-selectbox-options,
-    .bfh-selectbox-options ul {
-      min-width: 80px;
-      max-width: 80px;
-      width: 80px;
-    }
-  }
 
-  .bfh-selectbox-options ul li {
-      min-width: 78px;
-      max-width: 78px;
-      width: 78px;
-  }
+h2 {
+  font-size: 24px;
+  font-weight: bold;
+}
 
-  .bfh-selectbox-filter {
-      width: 60px;
-  }
+.modal-header,
+.modal-footer {
+  border: none;
+}
 
-  a.bfh-selectbox-option,
-  .bfh-selectbox-large {
-      width: 50px;
+.close {
+  opacity: 1;
+
+  .glyphicon::before {
+    color: #777;
   }
 }
 
-input.form-control.color-picker {
-    height: 38px;
+.glyphicon {
+  font-size: 18px;
+  vertical-align: top;
 }
-.font-picker-custom-font {
-    display: none;
+
+.btn-primary {
+  background-color: #2d60ad;
+  border-color: #2d60ad;
+  border-radius: 0;
+
+  &:hover {
+    background-color: #2d60ad;
+    border-color: #2d60ad;
+  }
 }
-.font-picker-text {
-    -webkit-border-radius: 8px;
-    -moz-border-radius: 8px;
-    border-radius: 8px;
-    background-color: #efefef;
-    text-align: center;
-    padding: 15px;
+
+.icon-right {
+  margin-left: 10px;
 }

--- a/test/e2e/font-picker-test.html
+++ b/test/e2e/font-picker-test.html
@@ -1,33 +1,35 @@
 <html>
-
-<!--link rel="stylesheet" href="//s3.amazonaws.com/rise-common-test/styles/glyphicons/glyphicons.min.css" -/-->
-<link rel="stylesheet" href="../../components/bootstrap/dist/css/bootstrap.css">
-<!-- <link rel="stylesheet" href="//s3.amazonaws.com/rise-common-test/styles/spectrum/spectrum.css"> -->
-<link rel="stylesheet" href="../../components/rv-bootstrap-formhelpers/dist/css/rv-bootstrap-formhelpers.css">
-<link rel="stylesheet" href="../../src/css/bootstrap-fontpicker.css" />
-<!-- <link rel="stylesheet" href="//s3.amazonaws.com/rise-common-test/styles/rise/css/rise.min.css"> -->
-
-<head><title>Font Picker - Test Page</title></head>
-
+<head>
+  <title>Font Picker - Test Page</title>
+  <link rel="stylesheet" href="../../components/bootstrap/dist/css/bootstrap.css">
+  <link rel="stylesheet" href="../../components/rv-bootstrap-formhelpers/dist/css/rv-bootstrap-formhelpers.css">
+  <link rel="stylesheet" href="../../src/css/bootstrap-fontpicker.css" />
+  <style>
+  #font-picker {
+    margin: 10px;
+    width: 250px;
+  }
+</style>
+</head>
 <body>
+  <div id="font-picker">
+  </div>
 
-<div id="font-picker">
-</div>
+  <script type="text/javascript" src="../../components/jquery/dist/jquery.js"></script>
+  <script type="text/javascript" src="../../components/bootstrap/dist/js/bootstrap.js"></script>
+  <script type="text/javascript" src="../../components/rv-bootstrap-formhelpers/dist/js/rv-bootstrap-formhelpers.js"></script>
+  <script type="text/javascript" src="../../src/js/config/config.js"></script>
+  <script type="text/javascript" src="../../src/templates/font-picker-template.js"></script>
+  <script type="text/javascript" src="../../src/js/font-picker/font-loader.js"></script>
+  <script type="text/javascript" src="../../src/js/font-picker/font-picker.js"></script>
 
-<script type="text/javascript" src="../../components/jquery/dist/jquery.js"></script>
-<script type="text/javascript" src="../../components/bootstrap/dist/js/bootstrap.js"></script>
-<script type="text/javascript" src="../../components/rv-bootstrap-formhelpers/dist/js/rv-bootstrap-formhelpers.js"></script>
-<script type="text/javascript" src="../../src/js/config/config.js"></script>
-<script type="text/javascript" src="../../src/templates/font-picker-template.js"></script>
-<script type="text/javascript" src="../../src/js/font-picker/font-loader.js"></script>
-<script type="text/javascript" src="../../src/js/font-picker/font-picker.js"></script>
-
-<script type="text/javascript">
-  $('#font-picker').fontPicker({
-    font: "Times New Roman", blank: false,
-    showCustom: true, showMore: true
-  });
-</script>
-
+  <script type="text/javascript">
+    $('#font-picker').fontPicker({
+      font: "Times New Roman",
+      blank: false,
+      showCustom: true,
+      showMore: true,
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Font size picker now works with the upgraded bootstrap-select component.
Updated the HTML template that the font picker uses.
Carried over shared styling from bootstrap.css and rise.css that font picker needs.
Removed obsolete font picker CSS.
Fixed problems with HTML structure in the font picker test page.

@settinghead
