### PR TITLE
Integrate URL Field component into Font Picker

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,12 @@
     "templates"
   ],
   "dependencies": {
-    "jquery": "1.11.0",
-    "bootstrap": "3.1.1",
-    "rv-bootstrap-formhelpers": "git://github.com/Rise-Vision/BootstrapFormHelpers#2.3.2-rv",
+    "angular": "~1.2.18",
+    "rv-bootstrap": "git://github.com/Rise-Vision/bootstrap#3.1.1-rv",
     "bootstrap-select": "1.5.4",
-    "angular": "~1.2.18"
+    "jquery": "1.11.0",
+    "rv-bootstrap-formhelpers": "git://github.com/Rise-Vision/BootstrapFormHelpers#2.3.3-rv",
+    "widget-settings-ui-components": "git://github.com/Rise-Vision/widget-settings-ui-components"
+
   }
 }

--- a/dist/js/bootstrap-font-picker.js
+++ b/dist/js/bootstrap-font-picker.js
@@ -57,9 +57,10 @@ TEMPLATES['font-picker-template.html'] = "<!-- Font Family -->\n" +
     "      </div>\n" +
     "      <div class=\"modal-body\">\n" +
     "        <div class=\"custom-font-error alert alert-danger\">\n" +
-    "          Custom Font is a required field.\n" +
+    "          Unable to validate the URL entered. Please un-check \"Validate URL\" to bypass validation.\n" +
     "        </div>\n" +
-    "        <input class=\"font-url form-control\" type=\"url\" placeholder=\"Font URL\">\n" +
+    "        <!--<input class=\"font-url form-control\" type=\"url\" placeholder=\"Font URL\">-->\n" +
+    "        <div class=\"url-field\"></div>\n" +
     "      </div>\n" +
     "      <div class=\"modal-footer no-border\">\n" +
     "        <button type=\"button\" class=\"save-custom-font btn btn-primary\">\n" +
@@ -143,7 +144,7 @@ if(typeof RiseVision === 'undefined') {
       $selectBox = null,
       $family = null,
       $customFont = null,
-      $fontURL = null,
+      $customFontUrlField = null,
       $customFontError = null,
       currentFont = "",
       customFontURL = "";
@@ -160,8 +161,8 @@ if(typeof RiseVision === 'undefined') {
 
       $selectBox = $element.find(".bfh-selectbox");
       $family = $element.find(".font-family");
-      $fontURL = $element.find(".font-url");
       $customFont = $element.find(".custom-font");
+      $customFontUrlField = $customFont.find(".url-field");
       $customFontError = $element.find(".custom-font-error");
 
       // Initialize font list.
@@ -171,8 +172,12 @@ if(typeof RiseVision === 'undefined') {
       $element.find(".bfh-googlefontlist").bfhgooglefontlist();
 
       // Initialize custom font.
-      $element.find(".font-url").val(options["font-url"]);
-      customFontURL = $fontURL.val();
+      $customFontUrlField.urlField({
+        url: options["font-url"]
+      });
+      $customFontUrlField = $customFontUrlField.data("plugin_urlField");
+
+      customFontURL = options["font-url"];
 
       _loadFont();
       _bind();
@@ -226,7 +231,6 @@ if(typeof RiseVision === 'undefined') {
           currentFont = $family.val();
           $customFontError.hide();
           $customFont.modal("show");
-          $fontURL.focus();
         }
         else {
           currentFont = $family.val();
@@ -241,10 +245,10 @@ if(typeof RiseVision === 'undefined') {
       $element.find(".save-custom-font").on("click", function() {
         var fontFamily = "";
 
-        customFontURL = $fontURL.val();
+        customFontURL = $customFontUrlField.getUrl();
         fontFamily = _getCustomFontName();
 
-        if (RiseVision.Common.Validation.isValidURL($fontURL.get(0))) {
+        if ($customFontUrlField.validateUrl()) {
           utils.loadCustomFont(fontFamily, customFontURL, options.contentDocument);
           $customFont.modal("hide");
           $selectBox.trigger("customFontSelected", [fontFamily, customFontURL]);
@@ -320,7 +324,7 @@ if(typeof RiseVision === 'undefined') {
     }
 
     function getFontURL() {
-      return $fontURL.val();
+      return $customFontUrlField.getUrl();
     }
 
     /*

--- a/src/html/font-picker-template.html
+++ b/src/html/font-picker-template.html
@@ -54,9 +54,9 @@
       </div>
       <div class="modal-body">
         <div class="custom-font-error alert alert-danger">
-          Custom Font is a required field.
+          Unable to validate the URL entered. Please un-check "Validate URL" to bypass validation.
         </div>
-        <input class="font-url form-control" type="url" placeholder="Font URL">
+        <div class="url-field"></div>
       </div>
       <div class="modal-footer no-border">
         <button type="button" class="save-custom-font btn btn-primary">

--- a/src/js/font-picker/font-picker.js
+++ b/src/js/font-picker/font-picker.js
@@ -15,7 +15,7 @@
       $selectBox = null,
       $family = null,
       $customFont = null,
-      $fontURL = null,
+      $customFontUrlField = null,
       $customFontError = null,
       currentFont = "",
       customFontURL = "";
@@ -32,8 +32,8 @@
 
       $selectBox = $element.find(".bfh-selectbox");
       $family = $element.find(".font-family");
-      $fontURL = $element.find(".font-url");
       $customFont = $element.find(".custom-font");
+      $customFontUrlField = $customFont.find(".url-field");
       $customFontError = $element.find(".custom-font-error");
 
       // Initialize font list.
@@ -43,8 +43,12 @@
       $element.find(".bfh-googlefontlist").bfhgooglefontlist();
 
       // Initialize custom font.
-      $element.find(".font-url").val(options["font-url"]);
-      customFontURL = $fontURL.val();
+      $customFontUrlField.urlField({
+        url: options["font-url"]
+      });
+      $customFontUrlField = $customFontUrlField.data("plugin_urlField");
+
+      customFontURL = options["font-url"];
 
       _loadFont();
       _bind();
@@ -98,7 +102,6 @@
           currentFont = $family.val();
           $customFontError.hide();
           $customFont.modal("show");
-          $fontURL.focus();
         }
         else {
           currentFont = $family.val();
@@ -113,10 +116,10 @@
       $element.find(".save-custom-font").on("click", function() {
         var fontFamily = "";
 
-        customFontURL = $fontURL.val();
+        customFontURL = $customFontUrlField.getUrl();
         fontFamily = _getCustomFontName();
 
-        if (RiseVision.Common.Validation.isValidURL($fontURL.get(0))) {
+        if ($customFontUrlField.validateUrl()) {
           utils.loadCustomFont(fontFamily, customFontURL, options.contentDocument);
           $customFont.modal("hide");
           $selectBox.trigger("customFontSelected", [fontFamily, customFontURL]);
@@ -192,7 +195,7 @@
     }
 
     function getFontURL() {
-      return $fontURL.val();
+      return $customFontUrlField.getUrl();
     }
 
     /*

--- a/test/e2e/font-picker-test.html
+++ b/test/e2e/font-picker-test.html
@@ -18,6 +18,7 @@
   <script type="text/javascript" src="../../components/jquery/dist/jquery.js"></script>
   <script type="text/javascript" src="../../components/bootstrap/dist/js/bootstrap.js"></script>
   <script type="text/javascript" src="../../components/rv-bootstrap-formhelpers/dist/js/rv-bootstrap-formhelpers.js"></script>
+  <script type="text/javascript" src="../../components/widget-settings-ui-components/dist/js/url-field.js"></script>
   <script type="text/javascript" src="../../src/js/config/config.js"></script>
   <script type="text/javascript" src="../../src/templates/font-picker-template.js"></script>
   <script type="text/javascript" src="../../src/js/font-picker/font-loader.js"></script>


### PR DESCRIPTION
- Update bower with new bootstrap-form-helpers tag 2.3.3-rv, bootstrap 3.1.1-rv, and widget-settings-ui-components
- Using the jQuery plugin of URL Field from widget-settings-ui-components in the font picker test file
- Updated font picker jQuery plugin to use URL field and replaced all logic where necessary
- Updated font picker template to implement use of URL field and updated alert message when validation fails
