### PR TITLE
Implement use of style-guide#0.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,11 +19,10 @@
   ],
   "dependencies": {
     "angular": "~1.2.18",
-    "rv-bootstrap": "git://github.com/Rise-Vision/bootstrap#3.1.1-rv",
     "bootstrap-select": "1.5.4",
     "jquery": "1.11.0",
     "rv-bootstrap-formhelpers": "git://github.com/Rise-Vision/BootstrapFormHelpers#2.3.3-rv",
+    "rv-style-guide": "git://github.com/Rise-Vision/style-guide#0.1.0",
     "widget-settings-ui-components": "git://github.com/Rise-Vision/widget-settings-ui-components"
-
   }
 }

--- a/dist/js/bootstrap-font-picker.js
+++ b/dist/js/bootstrap-font-picker.js
@@ -59,7 +59,6 @@ TEMPLATES['font-picker-template.html'] = "<!-- Font Family -->\n" +
     "        <div class=\"custom-font-error alert alert-danger\">\n" +
     "          Unable to validate the URL entered. Please un-check \"Validate URL\" to bypass validation.\n" +
     "        </div>\n" +
-    "        <!--<input class=\"font-url form-control\" type=\"url\" placeholder=\"Font URL\">-->\n" +
     "        <div class=\"url-field\"></div>\n" +
     "      </div>\n" +
     "      <div class=\"modal-footer no-border\">\n" +

--- a/test/e2e/font-picker-test.html
+++ b/test/e2e/font-picker-test.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>Font Picker - Test Page</title>
-  <link rel="stylesheet" href="../../components/bootstrap/dist/css/bootstrap.css">
+  <link rel="stylesheet" href="../../components/rv-style-guide/dist/css/rise.min.css">
   <link rel="stylesheet" href="../../components/rv-bootstrap-formhelpers/dist/css/rv-bootstrap-formhelpers.css">
   <link rel="stylesheet" href="../../src/css/bootstrap-fontpicker.css" />
   <style>

--- a/test/e2e/font-size-picker-test.html
+++ b/test/e2e/font-size-picker-test.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Font Size Picker - Test Page</title>
 
-  <link rel="stylesheet" href="../../components/bootstrap/dist/css/bootstrap.css">
+  <link rel="stylesheet" href="../../components/rv-style-guide/dist/css/rise.min.css">
   <link rel="stylesheet" href="../../components/bootstrap-select/bootstrap-select.css">
   <link rel="stylesheet" href="../../components/rv-bootstrap-formhelpers/dist/css/rv-bootstrap-formhelpers.css">
 </head>

--- a/test/e2e/test-ng.html
+++ b/test/e2e/test-ng.html
@@ -1,11 +1,8 @@
 <html>
 
-<!--link rel="stylesheet" href="//s3.amazonaws.com/rise-common-test/styles/glyphicons/glyphicons.min.css" -/-->
-<link rel="stylesheet" href="../../components/bootstrap/dist/css/bootstrap.css">
-<!-- <link rel="stylesheet" href="//s3.amazonaws.com/rise-common-test/styles/spectrum/spectrum.css"> -->
+<link rel="stylesheet" href="../../components/rv-style-guide/dist/css/rise.min.css">
 <link rel="stylesheet" href="../../components/bootstrap-formhelpers/dist/css/bootstrap-formhelpers.css">
 <link rel="stylesheet" href="../../css/bootstrap-fontpicker.css" />
-<!-- <link rel="stylesheet" href="//s3.amazonaws.com/rise-common-test/styles/rise/css/rise.min.css"> -->
 
 <head><title>Test Page</title></head>
 


### PR DESCRIPTION
- Modified bower to use style-guide#0.1.0
- Ensured compiled bootstrap-font-picker has the removed line of commented out code from template
- Using style-guide css in font-picker, font-size-picker, and test-ng test HTML files
