### PR TITLE
Update bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,12 +18,12 @@
     "templates"
   ],
   "dependencies": {
-    "angular": "~1.2.18",
+    "angular": "1.2.18",
     "bootstrap-select": "1.5.4",
-    "jquery": "1.11.0",
-    "rv-bootstrap-formhelpers": "https://github.com/Rise-Vision/BootstrapFormHelpers.git#2.3.4-rv",
+    "common": "https://github.com/Rise-Vision/common.git",
     "common-style": "https://github.com/Rise-Vision/common-style.git",
-    "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git",
-    "common": "git://github.com/Rise-Vision/common"
+    "jquery": "1.11.0",
+    "rv-bootstrap-formhelpers": "https://github.com/Rise-Vision/BootstrapFormHelpers.git#2.3.5-rv",
+    "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git"
   }
 }


### PR DESCRIPTION
This addresses issues with Bootstrap Form Helpers when running bower install, but it still errors out when installing widget-settings-ui-components. Alex, I see you mentioned this in HipChat on Friday. Was this ever resolved?

@alex-deaconu @stulees Please review. Thx.
