### PR TITLE
Revert "changed casper to use E2E_PORT if present"

### DIFF
--- a/test/e2e/font-picker-test.js
+++ b/test/e2e/font-picker-test.js
@@ -1,6 +1,5 @@
 casper.test.begin('font picker: font list', function (test) {
-    var e2ePort = process.env.E2E_PORT || 8099;
-    casper.start('http://localhost:'+e2ePort+'/test/e2e/font-picker-test.html', function () {
+    casper.start('http://localhost:8099/test/e2e/font-picker-test.html', function () {
         test.assertTitle('Font Picker - Test Page');
         //should Display "Times New Roman" by default
         test.assertSelectorHasText('.bfh-selectbox-option', 'Times New Roman');

--- a/test/e2e/font-size-picker-test.js
+++ b/test/e2e/font-size-picker-test.js
@@ -1,7 +1,5 @@
 casper.test.begin('font size picker: size list', function (test) {
-  var e2ePort = process.env.E2E_PORT || 8099;
-
-  casper.start('http://localhost:'+e2ePort+'/test/e2e/font-size-picker-test.html', function () {
+  casper.start('http://localhost:8099/test/e2e/font-size-picker-test.html', function () {
     test.assertTitle('Font Size Picker - Test Page', "Page title is the one expected");
     test.assertSelectorHasText('.filter-option', '18', "Default size is 18");
   });


### PR DESCRIPTION
Reverts Rise-Vision/bootstrap-form-components#55
